### PR TITLE
docker-compose.yml: network configuration to communicate between projects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       - "3355:3355"
     volumes:
       - ./docker_db:/usr/src/app/mockdb
+    networks:
+      - default
+      - lakat-backend
 
   flask-service:
     build: ./http-server
@@ -13,3 +16,7 @@ services:
       - "3356:3000"
     depends_on:
       - rpc-server
+
+networks:
+  lakat-backend:
+    name: lakat-backend


### PR DESCRIPTION
We run two docker-compose projects and thus have distinct networks due to project name prefixes added to the network name by default. I added lakat-backend network name to have network shared between RPC and Mediawiki.